### PR TITLE
Add Scrum-Roles. Fixes #20

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,10 @@
+# Scrum Roles
+
+| Name     | Username       | Roles                             |
+|----------|----------------|-----------------------------------|
+| Andreas  | chraebeli      | Developer                         |
+| Cyrill   | cyrillbolliger | Developer, DBA, stv. Scrum-Master |
+| Lorenz   | lbischof       | Developer                         |
+| Martin   | tscheckow      | Developer, Scrum-Master           |
+| Matthias | mkeller1992    | Developer                         |
+| Raphael  | raaph          | Developer                         |


### PR DESCRIPTION
Ich habe beim Scrum-Master die Developer Rolle gelassen, da er ja nicht zu 100% in der Scrum-Master Rolle tätig ist. Stimmt das so?