### PR TITLE
Update hibernate sequence. Fixes #41

### DIFF
--- a/data.sql
+++ b/data.sql
@@ -1,4 +1,4 @@
-INSERT INTO hibernate_sequence (next_val) VALUES (1);
+INSERT INTO hibernate_sequence (next_val) VALUES (100);
 
 INSERT INTO Person
         (id, firstName, lastName, address, city, dob, email, phone, zip)


### PR DESCRIPTION
Damit JPA nicht bei 1 anfängt bei den IDs, denn das gibt ein Konflikt mit den Testdaten. JPA benutzt default `SEQUENCE` für die Generation der IDs und nicht `IDENTITY`, welches ganz einfach die eingebaute DB `increment`-Funktion verwendet. Dies glaub aus Gründen der Persistierung, damit ein Objekt nicht erst ein ID erhält nach dem persistieren (?).